### PR TITLE
feat: add getCurrentAmplitude for live microphone metering

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,10 @@ Retrieve the current input amplitude (microphone level) as a normalized
 number in the `[0, 1]` range.
 
 Intended for driving live visualizations such as VU meters or waveforms
-while recording. Returns `0` when no recording is active. Safe to poll
-at any cadence (~60–100ms is typical for waveforms).
+while recording. Returns `0` when no recording is active. Designed for
+UI-rate polling — a 60–100 ms interval is a good starting point for a
+waveform. Avoid calling it in a tight loop; each call crosses the
+JS/native bridge.
 
 **Returns:** <code>Promise&lt;<a href="#getcurrentamplituderesult">GetCurrentAmplitudeResult</a>&gt;</code>
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npx cap sync
 * [`stopRecording()`](#stoprecording)
 * [`cancelRecording()`](#cancelrecording)
 * [`getRecordingStatus()`](#getrecordingstatus)
+* [`getCurrentAmplitude()`](#getcurrentamplitude)
 * [`checkPermissions()`](#checkpermissions)
 * [`requestPermissions()`](#requestpermissions)
 * [`addListener('recordingError', ...)`](#addlistenerrecordingerror-)
@@ -153,6 +154,26 @@ Retrieve the current recording status.
 **Returns:** <code>Promise&lt;<a href="#getrecordingstatusresult">GetRecordingStatusResult</a>&gt;</code>
 
 **Since:** 1.0.0
+
+--------------------
+
+
+### getCurrentAmplitude()
+
+```typescript
+getCurrentAmplitude() => Promise<GetCurrentAmplitudeResult>
+```
+
+Retrieve the current input amplitude (microphone level) as a normalized
+number in the `[0, 1]` range.
+
+Intended for driving live visualizations such as VU meters or waveforms
+while recording. Returns `0` when no recording is active. Safe to poll
+at any cadence (~60–100ms is typical for waveforms).
+
+**Returns:** <code>Promise&lt;<a href="#getcurrentamplituderesult">GetCurrentAmplitudeResult</a>&gt;</code>
+
+**Since:** 8.1.0
 
 --------------------
 
@@ -308,6 +329,15 @@ Result returned by {@link CapacitorAudioRecorderPlugin.getRecordingStatus}.
 | Prop         | Type                                                        | Description                   | Since |
 | ------------ | ----------------------------------------------------------- | ----------------------------- | ----- |
 | **`status`** | <code><a href="#recordingstatus">RecordingStatus</a></code> | The current recording status. | 1.0.0 |
+
+
+#### GetCurrentAmplitudeResult
+
+Result returned by {@link CapacitorAudioRecorderPlugin.getCurrentAmplitude}.
+
+| Prop        | Type                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Since |
+| ----------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`value`** | <code>number</code> | The current input amplitude normalized to the `[0, 1]` range, where `0` represents silence and `1` represents the maximum level the platform can report. The value is `0` when no recording is active. Note: the source signal differs between platforms — Android reports the peak sample amplitude since the last call, iOS reports the average power in dB converted to linear, and Web reports the RMS of the latest frame. Consumers that need cross-platform parity may want to apply a per-platform scaling curve. | 8.1.0 |
 
 
 #### PermissionStatus

--- a/android/src/main/java/app/capgo/audiorecorder/CapacitorAudioRecorderPlugin.java
+++ b/android/src/main/java/app/capgo/audiorecorder/CapacitorAudioRecorderPlugin.java
@@ -156,6 +156,25 @@ public class CapacitorAudioRecorderPlugin extends com.getcapacitor.Plugin {
     }
 
     @PluginMethod
+    public void getCurrentAmplitude(PluginCall call) {
+        JSObject result = new JSObject();
+        if (mediaRecorder == null || status != RecordingStatus.RECORDING) {
+            result.put("value", 0.0);
+            call.resolve(result);
+            return;
+        }
+        double value;
+        try {
+            int peak = mediaRecorder.getMaxAmplitude();
+            value = Math.max(0.0, Math.min(1.0, peak / 32767.0));
+        } catch (IllegalStateException ex) {
+            value = 0.0;
+        }
+        result.put("value", value);
+        call.resolve(result);
+    }
+
+    @PluginMethod
     public void checkPermissions(PluginCall call) {
         PermissionState state = getPermissionState("microphone");
         JSObject result = new JSObject();

--- a/ios/Sources/CapacitorAudioRecorderPlugin/CapacitorAudioRecorderPlugin.swift
+++ b/ios/Sources/CapacitorAudioRecorderPlugin/CapacitorAudioRecorderPlugin.swift
@@ -14,6 +14,7 @@ public class CapacitorAudioRecorderPlugin: CAPPlugin, CAPBridgedPlugin, AVAudioR
         CAPPluginMethod(name: "stopRecording", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "cancelRecording", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getRecordingStatus", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getCurrentAmplitude", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "checkPermissions", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "requestPermissions", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "removeAllListeners", returnType: CAPPluginReturnPromise),
@@ -129,6 +130,18 @@ public class CapacitorAudioRecorderPlugin: CAPPlugin, CAPBridgedPlugin, AVAudioR
         call.resolve(["status": status.rawValue])
     }
 
+    @objc func getCurrentAmplitude(_ call: CAPPluginCall) {
+        guard let recorder = audioRecorder, status == .recording else {
+            call.resolve(["value": 0.0])
+            return
+        }
+        recorder.updateMeters()
+        let averagePowerDb = Double(recorder.averagePower(forChannel: 0))
+        let linear: Double = averagePowerDb.isFinite ? pow(10.0, averagePowerDb / 20.0) : 0.0
+        let value = max(0.0, min(1.0, linear))
+        call.resolve(["value": value])
+    }
+
     @objc override public func checkPermissions(_ call: CAPPluginCall) {
         call.resolve(["recordAudio": microphonePermissionState()])
     }
@@ -210,6 +223,7 @@ public class CapacitorAudioRecorderPlugin: CAPPlugin, CAPBridgedPlugin, AVAudioR
 
         let recorder = try AVAudioRecorder(url: fileURL, settings: settings)
         recorder.delegate = self
+        recorder.isMeteringEnabled = true
         recorder.prepareToRecord()
         recorder.record()
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -15,6 +15,28 @@ export interface GetRecordingStatusResult {
 }
 
 /**
+ * Result returned by {@link CapacitorAudioRecorderPlugin.getCurrentAmplitude}.
+ *
+ * @since 8.1.0
+ */
+export interface GetCurrentAmplitudeResult {
+  /**
+   * The current input amplitude normalized to the `[0, 1]` range, where `0`
+   * represents silence and `1` represents the maximum level the platform can
+   * report. The value is `0` when no recording is active.
+   *
+   * Note: the source signal differs between platforms — Android reports the
+   * peak sample amplitude since the last call, iOS reports the average power
+   * in dB converted to linear, and Web reports the RMS of the latest frame.
+   * Consumers that need cross-platform parity may want to apply a
+   * per-platform scaling curve.
+   *
+   * @since 8.1.0
+   */
+  value: number;
+}
+
+/**
  * Options accepted by {@link CapacitorAudioRecorderPlugin.startRecording}.
  *
  * @since 1.0.0
@@ -213,6 +235,19 @@ export interface CapacitorAudioRecorderPlugin {
    * @since 1.0.0
    */
   getRecordingStatus(): Promise<GetRecordingStatusResult>;
+
+  /**
+   * Retrieve the current input amplitude (microphone level) as a normalized
+   * number in the `[0, 1]` range.
+   *
+   * Intended for driving live visualizations such as VU meters or waveforms
+   * while recording. Returns `0` when no recording is active. Safe to poll
+   * at any cadence (~60–100ms is typical for waveforms).
+   *
+   * @returns The current amplitude.
+   * @since 8.1.0
+   */
+  getCurrentAmplitude(): Promise<GetCurrentAmplitudeResult>;
 
   /**
    * Return the current permission state for accessing the microphone.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -241,8 +241,10 @@ export interface CapacitorAudioRecorderPlugin {
    * number in the `[0, 1]` range.
    *
    * Intended for driving live visualizations such as VU meters or waveforms
-   * while recording. Returns `0` when no recording is active. Safe to poll
-   * at any cadence (~60–100ms is typical for waveforms).
+   * while recording. Returns `0` when no recording is active. Designed for
+   * UI-rate polling — a 60–100 ms interval is a good starting point for a
+   * waveform. Avoid calling it in a tight loop; each call crosses the
+   * JS/native bridge.
    *
    * @returns The current amplitude.
    * @since 8.1.0

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,6 +2,7 @@ import { WebPlugin, type PluginListenerHandle } from '@capacitor/core';
 
 import type {
   CapacitorAudioRecorderPlugin,
+  GetCurrentAmplitudeResult,
   PermissionState,
   PermissionStatus,
   RecordingErrorEvent,
@@ -21,6 +22,9 @@ export class CapacitorAudioRecorderWeb extends WebPlugin implements CapacitorAud
   private accumulatedPauseDuration = 0;
   private stopResolver: ((result: StopRecordingResult) => void) | null = null;
   private stopRejector: ((reason?: any) => void) | null = null;
+  private audioContext: AudioContext | null = null;
+  private analyser: AnalyserNode | null = null;
+  private analyserBuffer: Float32Array<ArrayBuffer> | null = null;
 
   async startRecording(_options?: StartRecordingOptions): Promise<void> {
     if (this.status === RecordingStatus.Recording || this.status === RecordingStatus.Paused) {
@@ -75,6 +79,8 @@ export class CapacitorAudioRecorderWeb extends WebPlugin implements CapacitorAud
       this.resetStopHandlers();
       this.resetState();
     });
+
+    this.setupAnalyser();
 
     this.mediaRecorder.start();
     this.status = RecordingStatus.Recording;
@@ -157,6 +163,19 @@ export class CapacitorAudioRecorderWeb extends WebPlugin implements CapacitorAud
     return { status: this.status };
   }
 
+  async getCurrentAmplitude(): Promise<GetCurrentAmplitudeResult> {
+    if (this.status !== RecordingStatus.Recording || !this.analyser || !this.analyserBuffer) {
+      return { value: 0 };
+    }
+    this.analyser.getFloatTimeDomainData(this.analyserBuffer);
+    let sumOfSquares = 0;
+    for (const sample of this.analyserBuffer) {
+      sumOfSquares += sample * sample;
+    }
+    const rms = Math.sqrt(sumOfSquares / this.analyserBuffer.length);
+    return { value: Math.max(0, Math.min(1, rms)) };
+  }
+
   async checkPermissions(): Promise<PermissionStatus> {
     const state = await this.getPermissionState();
     return { recordAudio: state };
@@ -232,6 +251,7 @@ export class CapacitorAudioRecorderWeb extends WebPlugin implements CapacitorAud
     this.pausedTimestamp = null;
     this.accumulatedPauseDuration = 0;
     this.recordedChunks = [];
+    this.teardownAnalyser();
     this.cleanupMediaStream();
     if (this.mediaRecorder) {
       const recorder = this.mediaRecorder;
@@ -240,6 +260,49 @@ export class CapacitorAudioRecorderWeb extends WebPlugin implements CapacitorAud
       recorder.onerror = null;
     }
     this.mediaRecorder = null;
+  }
+
+  private setupAnalyser(): void {
+    if (!this.mediaStream) {
+      return;
+    }
+    try {
+      const AudioContextCtor: typeof AudioContext | undefined =
+        typeof AudioContext !== 'undefined'
+          ? AudioContext
+          : (globalThis as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      if (!AudioContextCtor) {
+        return;
+      }
+      const context = new AudioContextCtor();
+      const source = context.createMediaStreamSource(this.mediaStream);
+      const analyser = context.createAnalyser();
+      analyser.fftSize = 1024;
+      source.connect(analyser);
+      this.audioContext = context;
+      this.analyser = analyser;
+      this.analyserBuffer = new Float32Array(new ArrayBuffer(analyser.fftSize * Float32Array.BYTES_PER_ELEMENT));
+    } catch {
+      this.teardownAnalyser();
+    }
+  }
+
+  private teardownAnalyser(): void {
+    if (this.analyser) {
+      try {
+        this.analyser.disconnect();
+      } catch {
+        // Ignored.
+      }
+    }
+    this.analyser = null;
+    this.analyserBuffer = null;
+    if (this.audioContext) {
+      void this.audioContext.close().catch(() => {
+        // Ignored.
+      });
+    }
+    this.audioContext = null;
   }
 
   private cleanupMediaStream(): void {

--- a/src/web.ts
+++ b/src/web.ts
@@ -275,11 +275,11 @@ export class CapacitorAudioRecorderWeb extends WebPlugin implements CapacitorAud
         return;
       }
       const context = new AudioContextCtor();
+      this.audioContext = context;
       const source = context.createMediaStreamSource(this.mediaStream);
       const analyser = context.createAnalyser();
       analyser.fftSize = 1024;
       source.connect(analyser);
-      this.audioContext = context;
       this.analyser = analyser;
       this.analyserBuffer = new Float32Array(new ArrayBuffer(analyser.fftSize * Float32Array.BYTES_PER_ELEMENT));
     } catch {


### PR DESCRIPTION
## What
- Adds a new `getCurrentAmplitude()` plugin method that returns the current microphone input level as a normalized number in `[0, 1]`.
- Implemented on Android, iOS, and Web. All platforms return `0` when no recording is active.

## Why
Apps that render live waveforms, VU meters, or other recording visualizations currently have no way to read the input level while this plugin owns the recorder. Web consumers can work around it with an independent `AnalyserNode` on their own `MediaStream`, but on native the plugin owns the `MediaRecorder` / `AVAudioRecorder` and there is no public hook into its metering. Exposing a cheap, pollable `getCurrentAmplitude()` unblocks those UIs without forcing downstream forks.

## How
- **Android** (`CapacitorAudioRecorderPlugin.java`): new `@PluginMethod getCurrentAmplitude` reads `mediaRecorder.getMaxAmplitude()`, normalizes by `32767.0`, and clamps to `[0, 1]`. Returns `0` when no recording is active or if the recorder throws `IllegalStateException`.
- **iOS** (`CapacitorAudioRecorderPlugin.swift`): sets `isMeteringEnabled = true` when building the `AVAudioRecorder`, registers the new method in `pluginMethods`, and the `@objc func getCurrentAmplitude` calls `updateMeters()`, reads `averagePower(forChannel: 0)` (dB), converts to linear via `pow(10, dB/20)`, and clamps. Returns `0` when inactive or when the reported power is non-finite.
- **Web** (`web.ts`): spins up an `AnalyserNode` on the `MediaStream` source during `startRecording` and tears it down in `resetState`. `getCurrentAmplitude()` grabs a time-domain frame and returns its RMS clamped to `[0, 1]`. Supports the legacy `webkitAudioContext` fallback.
- **TS definitions** (`definitions.ts`): new `GetCurrentAmplitudeResult` interface and `getCurrentAmplitude()` on the plugin interface, with JSDoc noting that the underlying signal differs per platform (Android peak, iOS averagePower-linear, Web RMS) so consumers that need cross-platform parity may want to apply a per-platform scaling curve.
- **README**: regenerated via `bun run docgen` (no manual edits to `<docgen-*>` sections).

The change is purely additive and non-breaking; no existing method signatures, return shapes, or behaviors changed.

## Testing
- `bun run build` — green (TS compile + docgen + rollup bundle).
- `bun run check:wiring` — green.
- `bun run lint` — green (ESLint + Prettier + SwiftLint). The only remaining ESLint warning in `src/web.ts` (`_options` unused) is pre-existing and unrelated.
- `bun run verify:android` — `BUILD SUCCESSFUL`.
- `bun run verify:ios` — `BUILD SUCCEEDED`.

Closes https://github.com/Cap-go/capacitor-audio-recorder/issues/6